### PR TITLE
Wc customer workflow #13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ wp-config.php
 /wp-content/themes/**/
 !/wp-content/themes/customizr-pro-**
 !/wp-content/themes/twentytwenty-child
+!/wp-content/themes/twentytwenty-child/**
 
 
 # Plugins

--- a/wp-content/themes/twentytwenty-child/functions.php
+++ b/wp-content/themes/twentytwenty-child/functions.php
@@ -29,6 +29,8 @@ function theme_start_session()
         session_start();
 }
 
+/** WooCommerce Hooks */
+
 /**
  * OVERRIDE WooCommerce Templates
  */
@@ -36,8 +38,6 @@ add_action( 'after_setup_theme', 'mytheme_add_woocommerce_support' );
 function mytheme_add_woocommerce_support() {
     add_theme_support( 'woocommerce' );
 }
-
-/** Woo Commerce Hooks */
 
 /**
  * REMOVE Shipping and Billing Fields in Checkout
@@ -65,7 +65,7 @@ function custom_override_checkout_fields( $fields )
 }
 
 /**
- * REDIRECT Continue Shopping to "services" page
+ * REDIRECT "Continue Shopping" to "services" page
  */
 add_filter( 'woocommerce_continue_shopping_redirect', 'wc_custom_redirect_continue_shopping' );
 function wc_custom_redirect_continue_shopping()
@@ -121,3 +121,11 @@ function my_custom_checkout_field_display_admin_order_meta( $order )
             <span> Business Card $entry_id </span>
           </a>";
 }
+
+/**
+ * REMOVE related products output
+ *
+ * This hook removes the related products on each product page (Standard-Size Printing, Large Format Printing)
+ * @see - https://docs.woocommerce.com/document/remove-related-posts-output/
+ */
+remove_action( 'woocommerce_after_single_product_summary', 'woocommerce_output_related_products', 20 );

--- a/wp-content/themes/twentytwenty-child/functions.php
+++ b/wp-content/themes/twentytwenty-child/functions.php
@@ -216,13 +216,13 @@ function unset_specific_order_item_meta_data( $formatted_meta, $item )
 add_action( 'init', 'register_ready_for_pickup_order_status' );
 function register_ready_for_pickup_order_status()
 {
-    register_post_status( 'wc-ready-for-pickup', array(
+    register_post_status( 'wc-ready', array(
         'label' => 'Ready for Pick Up',
         'public' => true,
         'exclude_from_search' => false,
         'show_in_admin_all_list' => true,
         'show_in_admin_status_list' => true,
-        'label_count' => _n_noop( 'Your order is ready for pick up!', 'Your orders are ready for pick up' )
+        'label_count' => _n_noop( 'Ready for Pick Up', 'Ready for Pick Up' )    // Shows up under Order's tab / filter
     ) );
 }
 
@@ -238,24 +238,24 @@ function register_special_status()
         'exclude_from_search' => false,
         'show_in_admin_all_list' => true,
         'show_in_admin_status_list' => true,
-        'label_count' => _n_noop( 'Special Processing. Please Await for more notifications.', 'Special Processing. Please Await for more notifications.' )
+        'label_count' => _n_noop( 'Special', 'Special' )                        // Shows up under Order's tab / filter
     ) );
 }
 
 
 /**
- * FINISHING "Finshing" status
+ * FINISHING "Finishing" status
  */
 add_action( 'init', 'register_finishing_status' );
-function register_finshing_status()
+function register_finishing_status()
 {
-    register_post_status( 'wc-finshing', array(
-        'label' => 'Finshing',
+    register_post_status( 'wc-finishing', array(
+        'label' => 'Finishing',
         'public' => true,
         'exclude_from_search' => false,
         'show_in_admin_all_list' => true,
         'show_in_admin_status_list' => true,
-        'label_count' => 'Finishing touches... Almost done! Await for your pick email.'
+        'label_count' => 'Finishing'                                                                // Shows up under Order's tab / filter
     ) );
 }
 
@@ -265,8 +265,8 @@ function register_finshing_status()
  * @param $order_statuses - current order status in assoc array
  * @return array - updated order statuses
  */
-add_filter( 'wc_order_statuses', 'add_ready_to_pick_up_to_order_statuses' );
-function add_ready_to_pick_up_to_order_statuses( $order_statuses )
+add_filter( 'wc_order_statuses', 'add_custom_order_statuses' );
+function add_custom_order_statuses( $order_statuses )
 {
 
     $new_order_statuses = array();
@@ -289,7 +289,7 @@ function add_ready_to_pick_up_to_order_statuses( $order_statuses )
 
         // place ready for pick up after "On Hold"
         if ( 'wc-on-hold' === $key ) {
-            $new_order_statuses['wc-ready-for-pickup'] = 'Ready for Pick Up';
+            $new_order_statuses['wc-ready'] = 'Ready for Pick Up';
         }
     }
 

--- a/wp-content/themes/twentytwenty-child/functions.php
+++ b/wp-content/themes/twentytwenty-child/functions.php
@@ -192,13 +192,14 @@ function bc_entry_id_text_to_order_items( $item, $cart_item_key, $values, $order
 }
 
 /**
- * REMOVE PDF download link from emails and front
+ * ::IMPORTANT:: REMOVES PDF download link from emails and user dashboard (basically everyone except admin dashboard)
  */
 add_filter( 'woocommerce_order_item_get_formatted_meta_data', 'unset_specific_order_item_meta_data', 10, 2 );
 function unset_specific_order_item_meta_data( $formatted_meta, $item )
 {
 
-    if ( is_admin() || is_wc_endpoint_url() )
+    // If, they are admin, Business Card PDF metadata (link) will be visible
+    if ( is_admin() )
         return $formatted_meta;
 
     foreach ( $formatted_meta as $key => $meta ) {
@@ -208,7 +209,7 @@ function unset_specific_order_item_meta_data( $formatted_meta, $item )
     return $formatted_meta;
 }
 
-/** CUSTOM ORDER STATUS (NOT INCLUDED IN WOOCOMMERCE CORE) */
+/** CUSTOM ORDER STATUSES (NOT INCLUDED IN WOOCOMMERCE CORE) */
 
 /**
  * REGISTER "Ready for Pick Up" status

--- a/wp-content/themes/twentytwenty-child/functions.php
+++ b/wp-content/themes/twentytwenty-child/functions.php
@@ -29,6 +29,14 @@ function theme_start_session()
         session_start();
 }
 
+/**
+ * OVERRIDE WooCommerce Templates
+ */
+add_action( 'after_setup_theme', 'mytheme_add_woocommerce_support' );
+function mytheme_add_woocommerce_support() {
+    add_theme_support( 'woocommerce' );
+}
+
 /** Woo Commerce Hooks */
 
 /**

--- a/wp-content/themes/twentytwenty-child/functions.php
+++ b/wp-content/themes/twentytwenty-child/functions.php
@@ -31,16 +31,48 @@ function theme_start_session()
 
 /** WooCommerce Hooks */
 
+/** USER FRONT-END CHANGES */
+/**
+ * REMOVE related products output
+ *
+ * This hook removes the related products on each product page (Standard-Size Printing, Large Format Printing)
+ * @see - https://docs.woocommerce.com/document/remove-related-posts-output/
+ */
+remove_action( 'woocommerce_after_single_product_summary', 'woocommerce_output_related_products', 20 );
+
+/**
+ * REDIRECT "Continue Shopping" to "services" page
+ */
+add_filter( 'woocommerce_continue_shopping_redirect', 'wc_custom_redirect_continue_shopping' );
+function wc_custom_redirect_continue_shopping()
+{
+    //return your desired link here.
+    return get_site_url() . '/services';
+}
+
+/**
+ * CHANGE "Add to Cart" button text to "Add Order"
+ */
+add_filter( 'woocommerce_product_add_to_cart_text', 'woocommerce_custom_product_add_to_cart_text' );
+function woocommerce_custom_product_add_to_cart_text()
+{
+    return __( 'Add Order', 'woocommerce' );
+}
+
 /**
  * OVERRIDE WooCommerce Templates
  */
 add_action( 'after_setup_theme', 'mytheme_add_woocommerce_support' );
-function mytheme_add_woocommerce_support() {
+function mytheme_add_woocommerce_support()
+{
     add_theme_support( 'woocommerce' );
 }
 
 /**
  * REMOVE Shipping and Billing Fields in Checkout
+ *
+ * @param $fields - associative array of checkout fields
+ * @return mixed - updated fields with billing section stripped
  */
 add_filter( 'woocommerce_checkout_fields', 'custom_override_checkout_fields' );
 function custom_override_checkout_fields( $fields )
@@ -64,68 +96,88 @@ function custom_override_checkout_fields( $fields )
     return $fields;
 }
 
-/**
- * REDIRECT "Continue Shopping" to "services" page
- */
-add_filter( 'woocommerce_continue_shopping_redirect', 'wc_custom_redirect_continue_shopping' );
-function wc_custom_redirect_continue_shopping()
-{
-    //return your desired link here.
-    return get_site_url() . '/services';
-}
-
+/** BACK-END, METADATA, & WP ADMIN CHANGES  */
 
 /**
- * CHANGE "Add to Cart" button text to "Add Order"
- */
-add_filter( 'woocommerce_product_add_to_cart_text', 'woocommerce_custom_product_add_to_cart_text' );
-function woocommerce_custom_product_add_to_cart_text()
-{
-    return __( 'Add Order', 'woocommerce' );
-}
-
-
-/// HOOKS TO ATTACH ENTRY_ID TO ORDER META DATA
-/**
- * PROGRAMMATICALLY add entry_id to Product meta data. GF entry_id should be accessible from SESSIONS (set in plugin)
- */
-add_action( 'woocommerce_add_to_cart', 'add_to_cart_with_entry_id', 10, 6 );
-function add_to_cart_with_entry_id( $cart_item_key, $product_id, $quantity, $variation_id, $variation, $cart_item_data )
-{
-
-}
-
-/**
- * ADD the order meta with entry_id
- */
-add_action( 'woocommerce_checkout_update_order_meta', 'entry_id_update_order_meta' );
-function entry_id_update_order_meta( $order_id )
-{
-    session_start();
-    $entry_id = $_SESSION['entry_id'];
-    update_post_meta( $order_id, 'bc_entry_id', $entry_id );
-}
-
-/**
- * Display field value on the order edit page with a link to download
- * @TODO - will need to revise in the future. This is for business cards specifically...
- */
-add_action( 'woocommerce_admin_order_data_after_billing_address', 'my_custom_checkout_field_display_admin_order_meta', 10, 1 );
-function my_custom_checkout_field_display_admin_order_meta( $order )
-{
-    $entry_id = get_post_meta( $order->get_id(), 'bc_entry_id', true );
-    $uploads = wp_upload_dir();
-
-    echo "<strong style='color: black;'>" . __( 'Entry ID' ) . ":</strong>
-          <a href='" . esc_url( $uploads['baseurl'] . '/business_cards/business_card_' . $entry_id . '.pdf') . "'> 
-            <span> Business Card $entry_id </span>
-          </a>";
-}
-
-/**
- * REMOVE related products output
+ * ADD business card entry_id to cart item.
  *
- * This hook removes the related products on each product page (Standard-Size Printing, Large Format Printing)
- * @see - https://docs.woocommerce.com/document/remove-related-posts-output/
+ * @param array $cart_item_data
+ * @param int $product_id
+ * @param int $variation_id
+ *
+ * @return array
  */
-remove_action( 'woocommerce_after_single_product_summary', 'woocommerce_output_related_products', 20 );
+add_filter( 'woocommerce_add_cart_item_data', 'add_entry_id_to_cart_item', 10, 3 );
+function add_entry_id_to_cart_item( $cart_item_data, $product_id, $variation_id )
+{
+    $entry_id = $_SESSION['entry_id'];
+
+    if ( empty( $entry_id ) ) {
+        return $cart_item_data;
+    }
+
+    if ( $product_id === 39 ) {
+        $cart_item_data['bc_entry_id'] = $entry_id;
+    }
+
+    return $cart_item_data;
+}
+
+
+/**
+ * DISPLAY first + last name text of business card order in the cart.
+ *
+ * @param array $item_data
+ * @param array $cart_item
+ *
+ * @return array
+ */
+add_filter( 'woocommerce_get_item_data', 'business_card_display_text_cart', 10, 2 );
+function business_card_display_text_cart( $item_data, $cart_item )
+{
+    if ( empty( $cart_item['bc_entry_id'] ) ) {
+        return $item_data;
+    }
+
+    $item_data[] = array(
+        'key' => __( 'Business Card Entry ID', 'bc_entry_id' ),
+        'value' => wc_clean( $cart_item['bc_entry_id'] ),
+        'display' => '',
+    );
+
+    return $item_data;
+}
+
+
+/**
+ * ADD business card PDF link to
+ *
+ * @param WC_Order_Item_Product $item
+ * @param string $cart_item_key
+ * @param array $values
+ * @param WC_Order $order
+ */
+function bc_entry_id_text_to_order_items( $item, $cart_item_key, $values, $order )
+{
+    if ( empty( $values['bc_entry_id'] ) ) {
+        return;
+    }
+
+    // get upload directory + entry_id
+    $uploads = wp_upload_dir();
+    $entry_id = $values['bc_entry_id'];
+
+    // pull name from business_card
+    $entry = GFAPI::get_entry($entry_id);
+    $firstname = $entry['2.3'];
+    $lastname = $entry['2.6'];
+
+    //
+    $item->add_meta_data( __( 'Business Card Entry ID', 'bc_entry_id' ),
+        "
+            <a href='" . esc_url( $uploads['baseurl'] . '/business_cards/business_card_' . $entry_id . '.pdf' ) . "'>
+             " . "$firstname" . " " . "$lastname" . "
+            </a>
+        "
+    );
+}

--- a/wp-content/themes/twentytwenty-child/functions.php
+++ b/wp-content/themes/twentytwenty-child/functions.php
@@ -145,11 +145,19 @@ function business_card_display_text_cart( $item_data, $cart_item )
     $entry_id = $cart_item['bc_entry_id'];
     $entry = GFAPI::get_entry( $entry_id );
     $fullname = $entry['2.3'] . " " . $entry['2.6'];
+    $quantity = $entry['10'];
 
     // Display Fullname in cart + checkout page
     $item_data[] = array(
         'key' => __( 'Name', 'fullname' ),
         'value' => wc_clean( $fullname ),
+        'display' => '',
+    );
+
+    // Display Qty in cart + checkout page
+    $item_data[] = array(
+        'key' => __( 'Quantity', 'qty' ),
+        'value' => wc_clean( $quantity ),
         'display' => '',
     );
 
@@ -180,8 +188,9 @@ function bc_entry_id_text_to_order_items( $item, $cart_item_key, $values, $order
     $entry = GFAPI::get_entry( $entry_id );
     $firstname = $entry['2.3'];
     $lastname = $entry['2.6'];
+    $quantity = $entry['10'];
 
-    //
+    // add business card download link as meta data
     $item->add_meta_data( __( 'Business Card PDF', 'bc_entry_id' ),
         "
             <a href='" . esc_url( $uploads['baseurl'] . '/business_cards/business_card_' . $entry_id . '.pdf' ) . "'>
@@ -189,6 +198,10 @@ function bc_entry_id_text_to_order_items( $item, $cart_item_key, $values, $order
             </a>
         "
     );
+
+    // add quantity as meta data
+    $item->add_meta_data( __( 'Quantity', 'qty'), $quantity);
+
 }
 
 /**

--- a/wp-content/themes/twentytwenty-child/functions.php
+++ b/wp-content/themes/twentytwenty-child/functions.php
@@ -112,10 +112,12 @@ function add_entry_id_to_cart_item( $cart_item_data, $product_id, $variation_id 
 {
     $entry_id = $_SESSION['entry_id'];
 
+    // if entry_id for business card was not set in wp-print-preview, then return item as is
     if ( empty( $entry_id ) ) {
         return $cart_item_data;
     }
 
+    // if entry_id was set in $_SESSION, ensure that it can only be added to business card
     if ( $product_id === 39 ) {
         $cart_item_data['bc_entry_id'] = $entry_id;
     }
@@ -139,9 +141,15 @@ function business_card_display_text_cart( $item_data, $cart_item )
         return $item_data;
     }
 
+    // Extract Fullname from GF Entries
+    $entry_id = $cart_item['bc_entry_id'];
+    $entry = GFAPI::get_entry($entry_id);
+    $fullname = $entry['2.3'] . " " . $entry['2.6'];
+
+    // Display Fullname in cart + checkout page
     $item_data[] = array(
-        'key' => __( 'Business Card Entry ID', 'bc_entry_id' ),
-        'value' => wc_clean( $cart_item['bc_entry_id'] ),
+        'key' => __( 'Name', 'fullname' ),
+        'value' => wc_clean( $fullname ),
         'display' => '',
     );
 
@@ -150,13 +158,14 @@ function business_card_display_text_cart( $item_data, $cart_item )
 
 
 /**
- * ADD business card PDF link to
+ * ADD business card PDF link to "Edit Order" admin page
  *
  * @param WC_Order_Item_Product $item
  * @param string $cart_item_key
  * @param array $values
  * @param WC_Order $order
  */
+add_action( 'woocommerce_checkout_create_order_line_item', 'bc_entry_id_text_to_order_items', 10, 4 );
 function bc_entry_id_text_to_order_items( $item, $cart_item_key, $values, $order )
 {
     if ( empty( $values['bc_entry_id'] ) ) {

--- a/wp-content/themes/twentytwenty-child/style.css
+++ b/wp-content/themes/twentytwenty-child/style.css
@@ -18,3 +18,4 @@ html {
 .woocommerce {
   max-width: 1200px !important; /*Temporarily expand width of WooCommerce pages*/
 }
+

--- a/wp-content/themes/twentytwenty-child/style.css
+++ b/wp-content/themes/twentytwenty-child/style.css
@@ -12,3 +12,9 @@ html {
   box-sizing: border-box;
   font-size: 62.5%;
 }
+
+
+/** WooCommerce **/
+.woocommerce {
+  max-width: 1200px !important; /*Temporarily expand width of WooCommerce pages*/
+}

--- a/wp-content/themes/twentytwenty-child/woocommerce/checkout/thankyou.php
+++ b/wp-content/themes/twentytwenty-child/woocommerce/checkout/thankyou.php
@@ -14,6 +14,9 @@
  * @author    WooThemes
  * @package  WooCommerce/Templates
  * @version     3.2.0
+ *
+ * @edit - This page was edited at line 47 to add a 72 hour ETA when the order is placed. This page notifies
+ * immediately after the order
  */
 
 if ( !defined( 'ABSPATH' ) ) {

--- a/wp-content/themes/twentytwenty-child/woocommerce/checkout/thankyou.php
+++ b/wp-content/themes/twentytwenty-child/woocommerce/checkout/thankyou.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Thankyou page
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/checkout/thankyou.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see      https://docs.woocommerce.com/document/template-structure/
+ * @author    WooThemes
+ * @package  WooCommerce/Templates
+ * @version     3.2.0
+ */
+
+if ( !defined( 'ABSPATH' ) ) {
+    exit;
+}
+?>
+
+<div class="woocommerce-order">
+
+    <?php if ( $order ) : ?>
+
+        <?php if ( $order->has_status( 'failed' ) ) : ?>
+
+        <p class="woocommerce-notice woocommerce-notice--error woocommerce-thankyou-order-failed"><?php _e( 'Unfortunately your order cannot be processed as the originating bank/merchant has declined your transaction. Please attempt your purchase again.', 'woocommerce' ); ?></p>
+
+        <p class="woocommerce-notice woocommerce-notice--error woocommerce-thankyou-order-failed-actions">
+          <a href="<?php echo esc_url( $order->get_checkout_payment_url() ); ?>"
+             class="button pay"><?php _e( 'Pay', 'woocommerce' ) ?></a>
+            <?php if ( is_user_logged_in() ) : ?>
+              <a href="<?php echo esc_url( wc_get_page_permalink( 'myaccount' ) ); ?>"
+                 class="button pay"><?php _e( 'My account', 'woocommerce' ); ?></a>
+            <?php endif; ?>
+        </p>
+
+        <?php else : ?>
+
+        <p class="woocommerce-notice woocommerce-notice--success woocommerce-thankyou-order-received">
+            <?php echo apply_filters(
+                'woocommerce_thankyou_order_received_text', __(
+                'Thank you. Your order has been received. Please wait approximately 72 hours for your order to be finished',
+                'woocommerce'
+            ), $order ); ?>
+        </p>
+
+        <ul class="woocommerce-order-overview woocommerce-thankyou-order-details order_details">
+
+          <li class="woocommerce-order-overview__order order">
+              <?php _e( 'Order number:', 'woocommerce' ); ?>
+            <strong><?php echo $order->get_order_number(); ?></strong>
+          </li>
+
+          <li class="woocommerce-order-overview__date date">
+              <?php _e( 'Date:', 'woocommerce' ); ?>
+            <strong><?php echo wc_format_datetime( $order->get_date_created() ); ?></strong>
+          </li>
+
+            <?php if ( is_user_logged_in() && $order->get_user_id() === get_current_user_id() && $order->get_billing_email() ) : ?>
+              <li class="woocommerce-order-overview__email email">
+                  <?php _e( 'Email:', 'woocommerce' ); ?>
+                <strong><?php echo $order->get_billing_email(); ?></strong>
+              </li>
+            <?php endif; ?>
+
+          <li class="woocommerce-order-overview__total total">
+              <?php _e( 'Total:', 'woocommerce' ); ?>
+            <strong><?php echo $order->get_formatted_order_total(); ?></strong>
+          </li>
+
+            <?php if ( $order->get_payment_method_title() ) : ?>
+              <li class="woocommerce-order-overview__payment-method method">
+                  <?php _e( 'Payment method:', 'woocommerce' ); ?>
+                <strong><?php echo wp_kses_post( $order->get_payment_method_title() ); ?></strong>
+              </li>
+            <?php endif; ?>
+
+        </ul>
+
+        <?php endif; ?>
+
+        <?php do_action( 'woocommerce_thankyou_' . $order->get_payment_method(), $order->get_id() ); ?>
+        <?php do_action( 'woocommerce_thankyou', $order->get_id() ); ?>
+
+    <?php else : ?>
+
+      <p class="woocommerce-notice woocommerce-notice--success woocommerce-thankyou-order-received">
+          <?php echo apply_filters(
+              'woocommerce_thankyou_order_received_text',
+              __( 'Thank you. Your order has been received. Please wait approximately 72 hours for your order to be finished', 'woocommerce' ),
+              null
+          ); ?>
+      </p>
+
+    <?php endif; ?>
+
+</div>

--- a/wp-content/themes/twentytwenty-child/woocommerce/myaccount/form-login.php
+++ b/wp-content/themes/twentytwenty-child/woocommerce/myaccount/form-login.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Login Form
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/form-login.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see     https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates
+ * @version 3.6.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+do_action( 'woocommerce_before_customer_login_form' ); ?>
+
+<?php if ( 'yes' === get_option( 'woocommerce_enable_myaccount_registration' ) ) : ?>
+
+<div class="u-columns col2-set" id="customer_login">
+
+    <div class="u-column1 col-1">
+
+        <?php endif; ?>
+
+        <h2><?php esc_html_e( 'Login', 'woocommerce' ); ?></h2>
+
+        <form class="woocommerce-form woocommerce-form-login login" method="post">
+
+            <?php do_action( 'woocommerce_login_form_start' ); ?>
+
+            <p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
+                <label for="username"><?php esc_html_e( 'Username or email address', 'woocommerce' ); ?>&nbsp;<span class="required">*</span></label>
+                <input type="text" class="woocommerce-Input woocommerce-Input--text input-text" name="username" id="username" autocomplete="username" value="<?php echo ( ! empty( $_POST['username'] ) ) ? esc_attr( wp_unslash( $_POST['username'] ) ) : ''; ?>" /><?php // @codingStandardsIgnoreLine ?>
+            </p>
+            <p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
+                <label for="password"><?php esc_html_e( 'Password', 'woocommerce' ); ?>&nbsp;<span class="required">*</span></label>
+                <input class="woocommerce-Input woocommerce-Input--text input-text" type="password" name="password" id="password" autocomplete="current-password" />
+            </p>
+
+            <?php do_action( 'woocommerce_login_form' ); ?>
+
+            <p class="form-row">
+                <label class="woocommerce-form__label woocommerce-form__label-for-checkbox woocommerce-form-login__rememberme">
+                    <input class="woocommerce-form__input woocommerce-form__input-checkbox" name="rememberme" type="checkbox" id="rememberme" value="forever" /> <span><?php esc_html_e( 'Remember me', 'woocommerce' ); ?></span>
+                </label>
+                <?php wp_nonce_field( 'woocommerce-login', 'woocommerce-login-nonce' ); ?>
+                <button type="submit" class="woocommerce-button button woocommerce-form-login__submit" name="login" value="<?php esc_attr_e( 'Log in', 'woocommerce' ); ?>"><?php esc_html_e( 'Log in', 'woocommerce' ); ?></button>
+            </p>
+            <p class="woocommerce-LostPassword lost_password">
+                <a href="<?php echo esc_url( wp_lostpassword_url() ); ?>"><?php esc_html_e( 'Lost your password?', 'woocommerce' ); ?></a>
+            </p>
+
+            <?php do_action( 'woocommerce_login_form_end' ); ?>
+
+        </form>
+
+        <a href="/user-registration">Don't have an account? Sign Up here</a>
+
+        <?php if ( 'yes' === get_option( 'woocommerce_enable_myaccount_registration' ) ) : ?>
+
+    </div>
+
+    <div class="u-column2 col-2">
+
+        <h2><?php esc_html_e( 'Register', 'woocommerce' ); ?></h2>
+
+        <form method="post" class="woocommerce-form woocommerce-form-register register" <?php do_action( 'woocommerce_register_form_tag' ); ?> >
+
+            <?php do_action( 'woocommerce_register_form_start' ); ?>
+
+            <?php if ( 'no' === get_option( 'woocommerce_registration_generate_username' ) ) : ?>
+
+                <p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
+                    <label for="reg_username"><?php esc_html_e( 'Username', 'woocommerce' ); ?>&nbsp;<span class="required">*</span></label>
+                    <input type="text" class="woocommerce-Input woocommerce-Input--text input-text" name="username" id="reg_username" autocomplete="username" value="<?php echo ( ! empty( $_POST['username'] ) ) ? esc_attr( wp_unslash( $_POST['username'] ) ) : ''; ?>" /><?php // @codingStandardsIgnoreLine ?>
+                </p>
+
+            <?php endif; ?>
+
+            <p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
+                <label for="reg_email"><?php esc_html_e( 'Email address', 'woocommerce' ); ?>&nbsp;<span class="required">*</span></label>
+                <input type="email" class="woocommerce-Input woocommerce-Input--text input-text" name="email" id="reg_email" autocomplete="email" value="<?php echo ( ! empty( $_POST['email'] ) ) ? esc_attr( wp_unslash( $_POST['email'] ) ) : ''; ?>" /><?php // @codingStandardsIgnoreLine ?>
+            </p>
+
+            <?php if ( 'no' === get_option( 'woocommerce_registration_generate_password' ) ) : ?>
+
+                <p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
+                    <label for="reg_password"><?php esc_html_e( 'Password', 'woocommerce' ); ?>&nbsp;<span class="required">*</span></label>
+                    <input type="password" class="woocommerce-Input woocommerce-Input--text input-text" name="password" id="reg_password" autocomplete="new-password" />
+                </p>
+
+            <?php else : ?>
+
+                <p><?php esc_html_e( 'A password will be sent to your email address.', 'woocommerce' ); ?></p>
+
+            <?php endif; ?>
+
+            <?php do_action( 'woocommerce_register_form' ); ?>
+
+            <p class="woocommerce-FormRow form-row">
+                <?php wp_nonce_field( 'woocommerce-register', 'woocommerce-register-nonce' ); ?>
+                <button type="submit" class="woocommerce-Button woocommerce-button button woocommerce-form-register__submit" name="register" value="<?php esc_attr_e( 'Register', 'woocommerce' ); ?>"><?php esc_html_e( 'Register', 'woocommerce' ); ?></button>
+            </p>
+
+            <?php do_action( 'woocommerce_register_form_end' ); ?>
+
+        </form>
+
+    </div>
+
+</div>
+<?php endif; ?>
+
+<?php do_action( 'woocommerce_after_customer_login_form' ); ?>

--- a/wp-content/themes/twentytwenty-child/woocommerce/myaccount/form-login.php
+++ b/wp-content/themes/twentytwenty-child/woocommerce/myaccount/form-login.php
@@ -13,6 +13,8 @@
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
  * @version 3.6.0
+ *
+ * @edit - At line 66, I added a link to the register form for users without an account
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
|# Copy Center 2.0 Sprint 2 - https://projects.vta.org/versions/21

This PR request fulfills the requirements from Copy Center 2.0 Sprint 2. The sprint covers WooCommerce order functionalities including the order number, order queue, a standard ETA notification, custom work order statuses, and customer dashboard features.

Some features have already been included in WooCommerce, so those features will not have code for review.

### Testing
In order to perform a User Acceptance Test for this PR, please do the following the Development page:

**User**
1. Create a new account using a **vta.org** email. You can use your alias (first.last@vta.org) if you have already registered with your original email (last_f@vta.org) and vice versa.
2. Go through one of the service forms, fill out the form, and **"Add Order"** to cart.
3. Checkout inside the **Cart** page and place an order.
4. Check your user account email to see if you've received a 72-hour ETA email.
5. Go to the **My Account** page and under the **Orders** tab, you can view orders. There you can view your current orders. *
*NOTE:** You can only re-order past orders that have been marked **Completed**._

**Admin (You must be logged in on your WordPress admin account)**

1. On the WordPress admin page, go to the **WooCommerce** tab and select the **Orders**.
2. Select the order that you just submitted.
3. Select one of the custom order statuses ("Special", "Finishing", or "Ready For Pick Up") and hit **update**. This order status should reflect on the customer dashboard **as well as** send an automated email to the customer account.
**NOTE:** _You will get two emails if your customer email and admin email are the same._
4. The automated email message can also be customized on the WordPress admin side under **WooCommerce** > **Settings** and under the **Emails** tab, check for those custom order statuses' email templates.

### Code
The following code modifications for this repository can be found under `style.css` and `functions.php`. Additional code from my personal repository was used to create the custom email templates in a new plugin [WooCommerce Custom Emails](https://github.com/jpham93/wc-custom-emails). 

In the new plugin, please briefly review: 
- `templates/`
- `includes/class-woocommerce-custom-emails.php`
- `emails/`

### Requirements:
- [x] ~[|#311 Work Ticket Queue](https://projects.vta.org/projects/copy-center/work_packages/311)~ _(WooCommerce built-in feature)_
- [x] ~[|#315 Order numbers](https://projects.vta.org/projects/copy-center/work_packages/315)~ –_(WooCommerce built-in feature)_
- [x] [|#316 Copy Center ETA](https://projects.vta.org/projects/copy-center/work_packages/316) – Give a standard 72-hour window as a default notification. Allow this notification to be updated when ETA changes.
- [x] [|#317 Queue Order](https://projects.vta.org/projects/copy-center/work_packages/318)  –_(WooCommerce built-in feature)_
- [x] [|#318 Ready to Pickup Email](https://projects.vta.org/projects/copy-center/work_packages/318) – An email that notifies "Ready to pick up" as well as the cost related to the order. (We may want to implement the cost information in a later sprint)
- [x] ~[|#319 Reorder/ Order History](https://projects.vta.org/projects/copy-center/work_packages/319)~ – _(WooCommerce built-in feature)_
- [x] [|#322 Order Status](https://projects.vta.org/projects/copy-center/work_packages/322) – _(WooCommerce built-in feature)_ **Will need additional PHP code to create custom status + emails**. For custom Order Status email notifications, please refer to this repository: [WooCommerce Custom Emails](https://github.com/jpham93/wc-custom-emails)
- [x] ~[|#302 User Registration](https://projects.vta.org/projects/copy-center/work_packages/302) – After the user signs up, a confirmation email should be sent with an activation link.~ _Resolved with Post SMTP plugin and configuration on GF_