### PR TITLE
WC Customer Dashboard #22

### DIFF
--- a/wp-content/themes/customizr-pro-child/woocommerce/emails/email-order-details.php
+++ b/wp-content/themes/customizr-pro-child/woocommerce/emails/email-order-details.php
@@ -2,7 +2,7 @@
 /**
  * Order details table shown in emails.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/email-order-details.php.
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/email-order-details-item.php.
  *
  * HOWEVER, on occasion WooCommerce will need to update template files and you
  * (the theme developer) will need to copy the new files to your theme to

--- a/wp-content/themes/customizr-pro-child/woocommerce/emails/plain/email-order-details.php
+++ b/wp-content/themes/customizr-pro-child/woocommerce/emails/plain/email-order-details.php
@@ -2,7 +2,7 @@
 /**
  * Order details table shown in emails.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/email-order-details.php.
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/email-order-details-item.php.
  *
  * HOWEVER, on occasion WooCommerce will need to update template files and you
  * (the theme developer) will need to copy the new files to your theme to

--- a/wp-content/themes/customizr-pro-child/woocommerce/order/order-details.php
+++ b/wp-content/themes/customizr-pro-child/woocommerce/order/order-details.php
@@ -2,7 +2,7 @@
 /**
  * Order details
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/order/order-details.php.
+ * This template can be overridden by copying it to yourtheme/woocommerce/order/order-details-item.php.
  *
  * HOWEVER, on occasion WooCommerce will need to update template files and you
  * (the theme developer) will need to copy the new files to your theme to

--- a/wp-content/themes/customizr-pro-child/woocommerce/templates/emails/email-order-details.php
+++ b/wp-content/themes/customizr-pro-child/woocommerce/templates/emails/email-order-details.php
@@ -2,7 +2,7 @@
 /**
  * Order details table shown in emails.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/email-order-details.php.
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/email-order-details-item.php.
  *
  * HOWEVER, on occasion WooCommerce will need to update template files and you
  * (the theme developer) will need to copy the new files to your theme to

--- a/wp-content/themes/customizr-pro-child/woocommerce/templates/emails/plain/email-order-details.php
+++ b/wp-content/themes/customizr-pro-child/woocommerce/templates/emails/plain/email-order-details.php
@@ -2,7 +2,7 @@
 /**
  * Order details table shown in emails.
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/email-order-details.php.
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/email-order-details-item.php.
  *
  * HOWEVER, on occasion WooCommerce will need to update template files and you
  * (the theme developer) will need to copy the new files to your theme to

--- a/wp-content/themes/customizr-pro-child/woocommerce/templates/order/order-details.php
+++ b/wp-content/themes/customizr-pro-child/woocommerce/templates/order/order-details.php
@@ -2,7 +2,7 @@
 /**
  * Order details
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/order/order-details.php.
+ * This template can be overridden by copying it to yourtheme/woocommerce/order/order-details-item.php.
  *
  * HOWEVER, on occasion WooCommerce will need to update template files and you
  * (the theme developer) will need to copy the new files to your theme to

--- a/wp-content/themes/twentytwenty-child/functions.php
+++ b/wp-content/themes/twentytwenty-child/functions.php
@@ -34,7 +34,7 @@ function child_scripts()
 /**
  * REGISTER Custom Inner Footer Menu
  */
-add_action( 'wp_loaded', 'register_menus' );
+add_action( 'init', 'register_menus' );
 function register_menus()
 {
     $locations = array(
@@ -48,7 +48,7 @@ function register_menus()
  * Start user session for each individual user
  * REQUIRED for attaching meta data to business card product
  */
-add_action( "wp_loaded", "theme_start_session", 1 );
+add_action( "init", "theme_start_session", 1 );
 function theme_start_session()
 {
     if ( !session_id() )
@@ -390,7 +390,7 @@ function unset_specific_order_item_meta_data( $formatted_meta, $item )
 /**
  * REGISTER "Ready for Pick Up" status
  */
-add_action( 'wp_loaded', 'register_ready_for_pickup_order_status' );
+add_action( 'init', 'register_ready_for_pickup_order_status' );
 function register_ready_for_pickup_order_status()
 {
     register_post_status( 'wc-ready', array(
@@ -406,7 +406,7 @@ function register_ready_for_pickup_order_status()
 /**
  * REGISTER "Special" status
  */
-add_action( 'wp_loaded', 'register_special_status' );
+add_action( 'init', 'register_special_status' );
 function register_special_status()
 {
     register_post_status( 'wc-special', array(
@@ -423,7 +423,7 @@ function register_special_status()
 /**
  * REGISTER "Finishing" status
  */
-add_action( 'wp_loaded', 'register_finishing_status' );
+add_action( 'init', 'register_finishing_status' );
 function register_finishing_status()
 {
     register_post_status( 'wc-finishing', array(
@@ -439,7 +439,7 @@ function register_finishing_status()
 /**
  * REGISTER "Proof Ready" status
  */
-add_action( 'wp_loaded', 'register_proof_status' );
+add_action( 'init', 'register_proof_status' );
 function register_proof_status()
 {
     register_post_status( 'wc-proof', array(

--- a/wp-content/themes/twentytwenty-child/functions.php
+++ b/wp-content/themes/twentytwenty-child/functions.php
@@ -439,10 +439,10 @@ function register_finishing_status()
 /**
  * REGISTER "Proof Ready" status
  */
-add_action( 'wp_loaded', 'register_proof_ready_status' );
-function register_proof_ready_status()
+add_action( 'wp_loaded', 'register_proof_status' );
+function register_proof_status()
 {
-    register_post_status( 'wc-proof-ready', array(
+    register_post_status( 'wc-proof', array(
         'label' => 'Proof Ready',
         'public' => true,
         'exclude_from_search' => false,
@@ -476,7 +476,7 @@ function add_custom_order_statuses( $order_statuses )
 
         // place "Proof Ready" for pick up after "On Hold"
         if ( 'wc-on-hold' === $key ) {
-            $new_order_statuses['wc-proof-ready'] = 'Proof Ready';
+            $new_order_statuses['wc-proof'] = 'Proof Ready';
         }
 
         // place "Finishing" for pick up after "On Hold"

--- a/wp-content/themes/twentytwenty-child/functions.php
+++ b/wp-content/themes/twentytwenty-child/functions.php
@@ -243,6 +243,20 @@ function custom_override_checkout_fields( $fields )
     return $fields;
 }
 
+/**
+ * REMOVE Downloads & Address tab from "My Account"
+ */
+add_filter( 'woocommerce_account_menu_items', 'customer_downloads_addresss' );
+function customer_downloads_addresss ($items)
+{
+    error_log( json_encode($items), JSON_PRETTY_PRINT);
+
+    unset( $items['downloads'] );
+    unset( $items['edit-address'] );
+
+    return $items;
+}
+
 /** BACK-END, METADATA, & WP ADMIN CHANGES  */
 
 /**

--- a/wp-content/themes/twentytwenty-child/functions.php
+++ b/wp-content/themes/twentytwenty-child/functions.php
@@ -246,8 +246,8 @@ function custom_override_checkout_fields( $fields )
 /**
  * REMOVE Downloads & Address tab from "My Account"
  */
-add_filter( 'woocommerce_account_menu_items', 'customer_downloads_addresss' );
-function customer_downloads_addresss ($items)
+add_filter( 'woocommerce_account_menu_items', 'remove_customer_downloads_addresss' );
+function remove_customer_downloads_addresss ($items)
 {
     error_log( json_encode($items), JSON_PRETTY_PRINT);
 

--- a/wp-content/themes/twentytwenty-child/functions.php
+++ b/wp-content/themes/twentytwenty-child/functions.php
@@ -442,7 +442,7 @@ function register_finishing_status()
 add_action( 'wp_loaded', 'register_proof_ready_status' );
 function register_proof_ready_status()
 {
-    register_post_status( 'wc-finishing', array(
+    register_post_status( 'wc-proof-ready', array(
         'label' => 'Proof Ready',
         'public' => true,
         'exclude_from_search' => false,
@@ -474,6 +474,11 @@ function add_custom_order_statuses( $order_statuses )
             $new_order_statuses['wc-special'] = 'Special';
         }
 
+        // place "Proof Ready" for pick up after "On Hold"
+        if ( 'wc-on-hold' === $key ) {
+            $new_order_statuses['wc-proof-ready'] = 'Proof Ready';
+        }
+
         // place "Finishing" for pick up after "On Hold"
         if ( 'wc-on-hold' === $key ) {
             $new_order_statuses['wc-finishing'] = 'Finishing';
@@ -482,11 +487,6 @@ function add_custom_order_statuses( $order_statuses )
         // place 'Ready for Pick up' for pick up after "On Hold"
         if ( 'wc-on-hold' === $key ) {
             $new_order_statuses['wc-ready'] = 'Ready for Pick Up';
-        }
-
-        // place "Proof Ready" for pick up after "On Hold"
-        if ( 'wc-on-hold' === $key ) {
-            $new_order_statuses['proof-ready'] = 'Proof Ready';
         }
     }
 

--- a/wp-content/themes/twentytwenty-child/functions.php
+++ b/wp-content/themes/twentytwenty-child/functions.php
@@ -423,7 +423,7 @@ function register_special_status()
 
 
 /**
- * FINISHING "Finishing" status
+ * REGISTER "Finishing" status
  */
 add_action( 'wp_loaded', 'register_finishing_status' );
 function register_finishing_status()
@@ -435,6 +435,22 @@ function register_finishing_status()
         'show_in_admin_all_list' => true,
         'show_in_admin_status_list' => true,
         'label_count' => 'Finishing'                                                                // Shows up under Order's tab / filter
+    ) );
+}
+
+/**
+ * REGISTER "Proof Ready" status
+ */
+add_action( 'wp_loaded', 'register_proof_ready_status' );
+function register_proof_ready_status()
+{
+    register_post_status( 'wc-finishing', array(
+        'label' => 'Proof Ready',
+        'public' => true,
+        'exclude_from_search' => false,
+        'show_in_admin_all_list' => true,
+        'show_in_admin_status_list' => true,
+        'label_count' => 'Proof Ready'                                                                // Shows up under Order's tab / filter
     ) );
 }
 
@@ -460,14 +476,19 @@ function add_custom_order_statuses( $order_statuses )
             $new_order_statuses['wc-special'] = 'Special';
         }
 
-        // place special for pick up after "Finishing"
+        // place "Finishing" for pick up after "On Hold"
         if ( 'wc-on-hold' === $key ) {
             $new_order_statuses['wc-finishing'] = 'Finishing';
         }
 
-        // place ready for pick up after "On Hold"
+        // place 'Ready for Pick up' for pick up after "On Hold"
         if ( 'wc-on-hold' === $key ) {
             $new_order_statuses['wc-ready'] = 'Ready for Pick Up';
+        }
+
+        // place "Proof Ready" for pick up after "On Hold"
+        if ( 'wc-on-hold' === $key ) {
+            $new_order_statuses['proof-ready'] = 'Proof Ready';
         }
     }
 

--- a/wp-content/themes/twentytwenty-child/functions.php
+++ b/wp-content/themes/twentytwenty-child/functions.php
@@ -541,3 +541,9 @@ function date_validation( $result, $value, $form, $field )
 
     return $result;
 }
+
+
+apply_filters( 'woocommerce_order_shipping_to_display', 'admin_hide_shipping', 10, 2 );
+function admin_hide_shipping( $shipping, $tax_display ) {
+    error_log( json_encode( $shipping ), JSON_PRETTY_PRINT );
+}

--- a/wp-content/themes/twentytwenty-child/functions.php
+++ b/wp-content/themes/twentytwenty-child/functions.php
@@ -248,8 +248,6 @@ function custom_override_checkout_fields( $fields )
 add_filter( 'woocommerce_account_menu_items', 'remove_customer_downloads_addresss' );
 function remove_customer_downloads_addresss ($items)
 {
-    error_log( json_encode($items), JSON_PRETTY_PRINT);
-
     unset( $items['downloads'] );
     unset( $items['edit-address'] );
 
@@ -511,8 +509,6 @@ function date_validation( $result, $value, $form, $field )
 
     // today's day
     $day = date( 'l', $today );
-
-    error_log( json_encode( $today ), JSON_PRETTY_PRINT );
 
     // Wednesday, Thursday, Friday, & Saturday add 5 days
     if ( $day === 'Wednesday' || $day === 'Thursday' || $day === 'Friday' || $day === 'Saturday' ) {

--- a/wp-content/themes/twentytwenty-child/js/scripts.js
+++ b/wp-content/themes/twentytwenty-child/js/scripts.js
@@ -104,6 +104,31 @@ const ssp_staple_conditional_checkbox = ($, form_id) => {
   }
 }
 
+const levels_field_rendering_bug = ($, form_id) =>  {
+
+  if (form_id === 1) {
+
+    // levels input
+    const level_1 = $('#choice_1_62_0');
+    const level_2 = $('#choice_1_62_1');
+    const level_3 = $('#choice_1_62_2');
+
+    // conditional fields
+    const staple_field = $('#field_1_66');
+
+    // Level is selected
+    level_1.change(() => {
+      console.log('should work');
+      console.log(staple_field.css('display'));
+      staple_field.css('display', 'block !important');
+      staple_field.css('visibility', 'visible')
+      console.log(staple_field.css('display'));
+    });
+
+  }
+
+}
+
 /**
  * Standard-Size Printing Form Setup
  *
@@ -121,6 +146,9 @@ const ssp_form_setup = ($, form_id, current_page) => {
 
     // Add tab functionality to SSP
     bind_tabs_event($, form_id);
+
+    // Fix levels rendering
+    levels_field_rendering_bug($, form_id);
 
   }
 
@@ -140,3 +168,18 @@ jQuery(document).on('gform_post_render', (event, form_id, current_page) => {
   // Set up standard-size printing form
   ssp_form_setup($, form_id, current_page);
 });
+
+gform.addFilter( 'gform_conditional_logic_fields', 'set_conditional_field' );
+function set_conditional_field( options, form, selectedFieldId ){
+
+  console.log(form)
+
+  if ( form.id == 121 )
+  {
+    options.push( {
+      label: 'My Custom Field',
+      value: 5
+    } );
+  }
+  return options;
+}

--- a/wp-content/themes/twentytwenty-child/js/scripts.js
+++ b/wp-content/themes/twentytwenty-child/js/scripts.js
@@ -122,9 +122,6 @@ const ssp_form_setup = ($, form_id, current_page) => {
     // Add tab functionality to SSP
     bind_tabs_event($, form_id);
 
-    // Fix levels rendering
-    levels_field_rendering_bug($, form_id);
-
   }
 
 }

--- a/wp-content/themes/twentytwenty-child/js/scripts.js
+++ b/wp-content/themes/twentytwenty-child/js/scripts.js
@@ -104,31 +104,6 @@ const ssp_staple_conditional_checkbox = ($, form_id) => {
   }
 }
 
-const levels_field_rendering_bug = ($, form_id) =>  {
-
-  if (form_id === 1) {
-
-    // levels input
-    const level_1 = $('#choice_1_62_0');
-    const level_2 = $('#choice_1_62_1');
-    const level_3 = $('#choice_1_62_2');
-
-    // conditional fields
-    const staple_field = $('#field_1_66');
-
-    // Level is selected
-    level_1.change(() => {
-      console.log('should work');
-      console.log(staple_field.css('display'));
-      staple_field.css('display', 'block !important');
-      staple_field.css('visibility', 'visible')
-      console.log(staple_field.css('display'));
-    });
-
-  }
-
-}
-
 /**
  * Standard-Size Printing Form Setup
  *
@@ -168,18 +143,3 @@ jQuery(document).on('gform_post_render', (event, form_id, current_page) => {
   // Set up standard-size printing form
   ssp_form_setup($, form_id, current_page);
 });
-
-gform.addFilter( 'gform_conditional_logic_fields', 'set_conditional_field' );
-function set_conditional_field( options, form, selectedFieldId ){
-
-  console.log(form)
-
-  if ( form.id == 121 )
-  {
-    options.push( {
-      label: 'My Custom Field',
-      value: 5
-    } );
-  }
-  return options;
-}

--- a/wp-content/themes/twentytwenty-child/style.css
+++ b/wp-content/themes/twentytwenty-child/style.css
@@ -1318,9 +1318,10 @@ div.woocommerce-product-gallery.woocommerce-product-gallery--without-images.imag
 WooCommerce Pages
 - Remove extra spacing inside woocommerce pages
  */
+.woocommerce-cart #site-content .woocommerce,
 .woocommerce-account #site-content .woocommerce {
   padding: 0;
-  margin: 0;
+  margin: auto;
 }
 
 /**

--- a/wp-content/themes/twentytwenty-child/style.css
+++ b/wp-content/themes/twentytwenty-child/style.css
@@ -1379,10 +1379,11 @@ button.single_add_to_cart_button.button {
 }
 
 /**
-Quantity Box
+Quantity Box in Forms
 - position to the left of "Add to Cart" button
  */
-div.quantity {
+form.cc-form div.quantity {
   position: absolute;
   right: calc(115px + 6rem);
 }
+

--- a/wp-content/themes/twentytwenty-child/style.css
+++ b/wp-content/themes/twentytwenty-child/style.css
@@ -657,7 +657,7 @@ GF form validation
 - position element above others
  */
 #gform_wrapper_1 > div.validation_error,
-.gform_wrapper form div.gf_page_steps+div.validation_error {
+form.cc-form .gform_wrapper form div.gf_page_steps+div.validation_error {
   background: var(--light-gray);
   margin-top: 0;
   margin-bottom: 0;
@@ -680,7 +680,7 @@ Form Body (Child of GF Form Element)
 - make it relative to position button container (absolute)
 - add inner spacing
  */
-form div.gform_body {
+form.cc-form div.gform_body {
   position: relative;
   background: var(--light-gray);
   padding: 2rem;
@@ -763,7 +763,7 @@ Form Fields Wrapper
 @TODO - may be GLOBAL in the future
 @TODO - might be a global FORM style in the future
  */
-form div.gform_body ul.gform_fields {
+form.form-cc div.gform_body ul.gform_fields {
   display: flex;
   flex-wrap: wrap;
   align-items: start;

--- a/wp-content/themes/twentytwenty-child/style.css
+++ b/wp-content/themes/twentytwenty-child/style.css
@@ -933,11 +933,11 @@ Business Card Preview Button Container
 - add spacing to the bottom
  */
 article#post-157.post-157 #confirm-bc > div.bc-preview-button-container {
-  display: flex;
-  flex-grow: 0;
-  flex-shrink: 0;
-  justify-content: flex-end;
-  margin-bottom: 1rem;
+  position: absolute;
+}
+
+article#post-157.post-157 #confirm-bc > div.bc-preview-button-container button.bc-preview-cancel {
+  width: 13rem;
 }
 
 /**

--- a/wp-content/themes/twentytwenty-child/style.css
+++ b/wp-content/themes/twentytwenty-child/style.css
@@ -1325,6 +1325,14 @@ WooCommerce Summary (Gravity Forms)
 }
 
 /**
+WooCommerce Cart Header
+- remove strange padding from this single page header
+ */
+.woocommerce-cart #site-content .entry-header {
+  padding: 0;
+}
+
+/**
 Categories
 - hide
  */

--- a/wp-content/themes/twentytwenty-child/style.css
+++ b/wp-content/themes/twentytwenty-child/style.css
@@ -1297,6 +1297,25 @@ form.standard-size-form div.gform_body div.gform_page ul.gform_fields li.gfield.
   }
 }
 
+/********************************/
+/** GF: Confirmed Account PAGE **/
+/********************************/
+
+/**
+Main Container
+ */
+div#content.widecolumn {
+  text-align: center;
+  min-height: 60vh;
+  background: var(--lighter-gray);
+  padding: 3rem 0;
+}
+
+div#content.widecolumn p.lead-in {
+  max-width: 768px;
+  margin: auto;
+}
+
 /*******************************/
 /** WOOCOMMERCE GLOBAL STYLES **/
 /*******************************/

--- a/wp-content/themes/twentytwenty-child/style.css
+++ b/wp-content/themes/twentytwenty-child/style.css
@@ -763,7 +763,7 @@ Form Fields Wrapper
 @TODO - may be GLOBAL in the future
 @TODO - might be a global FORM style in the future
  */
-form.form-cc div.gform_body ul.gform_fields {
+form.cc-form div.gform_body ul.gform_fields {
   display: flex;
   flex-wrap: wrap;
   align-items: start;

--- a/wp-content/themes/twentytwenty-child/style.css
+++ b/wp-content/themes/twentytwenty-child/style.css
@@ -1315,6 +1315,15 @@ div.woocommerce-product-gallery.woocommerce-product-gallery--without-images.imag
 }
 
 /**
+WooCommerce Pages
+- Remove extra spacing inside woocommerce pages
+ */
+.woocommerce-account #site-content .woocommerce {
+  padding: 0;
+  margin: 0;
+}
+
+/**
 WooCommerce Summary (Gravity Forms)
 - expand container to fit the entire page
  */

--- a/wp-content/themes/twentytwenty-child/template-parts/content.php
+++ b/wp-content/themes/twentytwenty-child/template-parts/content.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * The child template for displaying content
+ *
+ * Used for both singular and index.
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ *
+ * @package WordPress
+ * @subpackage Twenty_Twenty
+ * @since Twenty Twenty 1.0
+ *
+ * TEMPLATE OVERRIDE - added query param for email confirmation (line 41)
+ */
+
+?>
+
+<article <?php post_class(); ?> id="post-<?php the_ID(); ?>">
+
+    <?php
+
+    get_template_part( 'template-parts/entry-header' );
+
+    if ( ! is_search() ) {
+        get_template_part( 'template-parts/featured-image' );
+    }
+
+    ?>
+
+    <div class="post-inner <?php echo is_page_template( 'templates/template-full-width.php' ) ? '' : 'thin'; ?> ">
+
+        <div class="entry-content">
+
+            <?php
+            if ( is_search() || ! is_singular() && 'summary' === get_theme_mod( 'blog_content', 'full' ) ) {
+                the_excerpt();
+            } else {
+                the_content( __( 'Continue reading', 'twentytwenty' ) );
+            }
+
+            // Check if email is set as a query param and if it is /email-confirmation page
+            if ( isset ( $_GET['email'] ) && get_page_uri( get_the_ID() ) == 'email-confirmation' ) {
+              $email = $_GET['email'];
+              echo "
+                <span class='email-registration'>Sent to email: <strong>$email</strong></span>
+              ";
+            }
+            ?>
+
+        </div><!-- .entry-content -->
+
+    </div><!-- .post-inner -->
+
+    <div class="section-inner">
+        <?php
+        wp_link_pages(
+            array(
+                'before'      => '<nav class="post-nav-links bg-light-background" aria-label="' . esc_attr__( 'Page', 'twentytwenty' ) . '"><span class="label">' . __( 'Pages:', 'twentytwenty' ) . '</span>',
+                'after'       => '</nav>',
+                'link_before' => '<span class="page-number">',
+                'link_after'  => '</span>',
+            )
+        );
+
+        edit_post_link();
+
+        // Single bottom post meta.
+        twentytwenty_the_post_meta( get_the_ID(), 'single-bottom' );
+
+        if ( is_single() ) {
+
+            get_template_part( 'template-parts/entry-author-bio' );
+
+        }
+        ?>
+
+    </div><!-- .section-inner -->
+
+    <?php
+
+    if ( is_single() ) {
+
+        get_template_part( 'template-parts/navigation' );
+
+    }
+
+    /**
+     *  Output comments wrapper if it's a post, or if comments are open,
+     * or if there's a comment number – and check for password.
+     * */
+    if ( ( is_single() || is_page() ) && ( comments_open() || get_comments_number() ) && ! post_password_required() ) {
+        ?>
+
+        <div class="comments-wrapper section-inner">
+
+            <?php comments_template(); ?>
+
+        </div><!-- .comments-wrapper -->
+
+        <?php
+    }
+    ?>
+
+</article><!-- .post -->

--- a/wp-content/themes/twentytwenty-child/woocommerce/cart/cart-totals.php
+++ b/wp-content/themes/twentytwenty-child/woocommerce/cart/cart-totals.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Cart totals
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/cart/cart-totals.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see     https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates
+ * @version 2.3.6
+ *
+ * TEMPLATE OVERRIDE - Remove cart totals (Deleted entire file)
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+?>

--- a/wp-content/themes/twentytwenty-child/woocommerce/cart/cart-totals.php
+++ b/wp-content/themes/twentytwenty-child/woocommerce/cart/cart-totals.php
@@ -14,9 +14,18 @@
  * @package WooCommerce/Templates
  * @version 2.3.6
  *
- * TEMPLATE OVERRIDE - Remove cart totals (Deleted entire file)
+ * TEMPLATE OVERRIDE - Remove cart totals (Deleted entire file minus proceed to checkout)
  */
 
 defined( 'ABSPATH' ) || exit;
 
 ?>
+<div class="cart_totals <?php echo ( WC()->customer->has_calculated_shipping() ) ? 'calculated_shipping' : ''; ?>">
+
+    <div class="wc-proceed-to-checkout">
+        <?php do_action( 'woocommerce_proceed_to_checkout' ); ?>
+    </div>
+
+    <?php do_action( 'woocommerce_after_cart_totals' ); ?>
+
+</div>

--- a/wp-content/themes/twentytwenty-child/woocommerce/cart/cart.php
+++ b/wp-content/themes/twentytwenty-child/woocommerce/cart/cart.php
@@ -30,7 +30,7 @@ do_action( 'woocommerce_before_cart' ); ?>
             <th class="product-remove">&nbsp;</th>
             <th class="product-thumbnail">&nbsp;</th>
             <th class="product-name"><?php esc_html_e( 'Product', 'woocommerce' ); ?></th>
-            <th class="product-price"><?php esc_html_e( 'Price', 'woocommerce' ); ?></th>
+            <!--Remove Pricing-->
             <th class="product-quantity"><?php esc_html_e( 'Quantity', 'woocommerce' ); ?></th>
         </tr>
         </thead>
@@ -95,11 +95,7 @@ do_action( 'woocommerce_before_cart' ); ?>
                         ?>
                     </td>
 
-                    <td class="product-price" data-title="<?php esc_attr_e( 'Price', 'woocommerce' ); ?>">
-                        <?php
-                        echo apply_filters( 'woocommerce_cart_item_price', WC()->cart->get_product_price( $_product ), $cart_item, $cart_item_key ); // PHPCS: XSS ok.
-                        ?>
-                    </td>
+                    <!--Remove Price-->
 
                     <td class="product-quantity" data-title="<?php esc_attr_e( 'Quantity', 'woocommerce' ); ?>">
                         <?php

--- a/wp-content/themes/twentytwenty-child/woocommerce/cart/cart.php
+++ b/wp-content/themes/twentytwenty-child/woocommerce/cart/cart.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Cart Page
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/cart/cart.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see     https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates
+ * @version 3.8.0
+ *
+ * TEMPLATE OVERRIDE - removed subtotal (line 126)
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+do_action( 'woocommerce_before_cart' ); ?>
+
+<form class="woocommerce-cart-form" action="<?php echo esc_url( wc_get_cart_url() ); ?>" method="post">
+    <?php do_action( 'woocommerce_before_cart_table' ); ?>
+
+    <table class="shop_table shop_table_responsive cart woocommerce-cart-form__contents" cellspacing="0">
+        <thead>
+        <tr>
+            <th class="product-remove">&nbsp;</th>
+            <th class="product-thumbnail">&nbsp;</th>
+            <th class="product-name"><?php esc_html_e( 'Product', 'woocommerce' ); ?></th>
+            <th class="product-price"><?php esc_html_e( 'Price', 'woocommerce' ); ?></th>
+            <th class="product-quantity"><?php esc_html_e( 'Quantity', 'woocommerce' ); ?></th>
+        </tr>
+        </thead>
+        <tbody>
+        <?php do_action( 'woocommerce_before_cart_contents' ); ?>
+
+        <?php
+        foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
+            $_product   = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
+            $product_id = apply_filters( 'woocommerce_cart_item_product_id', $cart_item['product_id'], $cart_item, $cart_item_key );
+
+            if ( $_product && $_product->exists() && $cart_item['quantity'] > 0 && apply_filters( 'woocommerce_cart_item_visible', true, $cart_item, $cart_item_key ) ) {
+                $product_permalink = apply_filters( 'woocommerce_cart_item_permalink', $_product->is_visible() ? $_product->get_permalink( $cart_item ) : '', $cart_item, $cart_item_key );
+                ?>
+                <tr class="woocommerce-cart-form__cart-item <?php echo esc_attr( apply_filters( 'woocommerce_cart_item_class', 'cart_item', $cart_item, $cart_item_key ) ); ?>">
+
+                    <td class="product-remove">
+                        <?php
+                        echo apply_filters( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                            'woocommerce_cart_item_remove_link',
+                            sprintf(
+                                '<a href="%s" class="remove" aria-label="%s" data-product_id="%s" data-product_sku="%s">&times;</a>',
+                                esc_url( wc_get_cart_remove_url( $cart_item_key ) ),
+                                esc_html__( 'Remove this item', 'woocommerce' ),
+                                esc_attr( $product_id ),
+                                esc_attr( $_product->get_sku() )
+                            ),
+                            $cart_item_key
+                        );
+                        ?>
+                    </td>
+
+                    <td class="product-thumbnail">
+                        <?php
+                        $thumbnail = apply_filters( 'woocommerce_cart_item_thumbnail', $_product->get_image(), $cart_item, $cart_item_key );
+
+                        if ( ! $product_permalink ) {
+                            echo $thumbnail; // PHPCS: XSS ok.
+                        } else {
+                            printf( '<a href="%s">%s</a>', esc_url( $product_permalink ), $thumbnail ); // PHPCS: XSS ok.
+                        }
+                        ?>
+                    </td>
+
+                    <td class="product-name" data-title="<?php esc_attr_e( 'Product', 'woocommerce' ); ?>">
+                        <?php
+                        if ( ! $product_permalink ) {
+                            echo wp_kses_post( apply_filters( 'woocommerce_cart_item_name', $_product->get_name(), $cart_item, $cart_item_key ) . '&nbsp;' );
+                        } else {
+                            echo wp_kses_post( apply_filters( 'woocommerce_cart_item_name', sprintf( '<a href="%s">%s</a>', esc_url( $product_permalink ), $_product->get_name() ), $cart_item, $cart_item_key ) );
+                        }
+
+                        do_action( 'woocommerce_after_cart_item_name', $cart_item, $cart_item_key );
+
+                        // Meta data.
+                        echo wc_get_formatted_cart_item_data( $cart_item ); // PHPCS: XSS ok.
+
+                        // Backorder notification.
+                        if ( $_product->backorders_require_notification() && $_product->is_on_backorder( $cart_item['quantity'] ) ) {
+                            echo wp_kses_post( apply_filters( 'woocommerce_cart_item_backorder_notification', '<p class="backorder_notification">' . esc_html__( 'Available on backorder', 'woocommerce' ) . '</p>', $product_id ) );
+                        }
+                        ?>
+                    </td>
+
+                    <td class="product-price" data-title="<?php esc_attr_e( 'Price', 'woocommerce' ); ?>">
+                        <?php
+                        echo apply_filters( 'woocommerce_cart_item_price', WC()->cart->get_product_price( $_product ), $cart_item, $cart_item_key ); // PHPCS: XSS ok.
+                        ?>
+                    </td>
+
+                    <td class="product-quantity" data-title="<?php esc_attr_e( 'Quantity', 'woocommerce' ); ?>">
+                        <?php
+                        if ( $_product->is_sold_individually() ) {
+                            $product_quantity = sprintf( '1 <input type="hidden" name="cart[%s][qty]" value="1" />', $cart_item_key );
+                        } else {
+                            $product_quantity = woocommerce_quantity_input(
+                                array(
+                                    'input_name'   => "cart[{$cart_item_key}][qty]",
+                                    'input_value'  => $cart_item['quantity'],
+                                    'max_value'    => $_product->get_max_purchase_quantity(),
+                                    'min_value'    => '0',
+                                    'product_name' => $_product->get_name(),
+                                ),
+                                $_product,
+                                false
+                            );
+                        }
+
+                        echo apply_filters( 'woocommerce_cart_item_quantity', $product_quantity, $cart_item_key, $cart_item ); // PHPCS: XSS ok.
+                        ?>
+                    </td>
+
+                    <!--Removed Subtotal-->
+                </tr>
+                <?php
+            }
+        }
+        ?>
+
+        <?php do_action( 'woocommerce_cart_contents' ); ?>
+
+        <tr>
+            <td colspan="6" class="actions">
+
+                <?php if ( wc_coupons_enabled() ) { ?>
+                    <div class="coupon">
+                        <label for="coupon_code"><?php esc_html_e( 'Coupon:', 'woocommerce' ); ?></label> <input type="text" name="coupon_code" class="input-text" id="coupon_code" value="" placeholder="<?php esc_attr_e( 'Coupon code', 'woocommerce' ); ?>" /> <button type="submit" class="button" name="apply_coupon" value="<?php esc_attr_e( 'Apply coupon', 'woocommerce' ); ?>"><?php esc_attr_e( 'Apply coupon', 'woocommerce' ); ?></button>
+                        <?php do_action( 'woocommerce_cart_coupon' ); ?>
+                    </div>
+                <?php } ?>
+
+                <button type="submit" class="button" name="update_cart" value="<?php esc_attr_e( 'Update cart', 'woocommerce' ); ?>"><?php esc_html_e( 'Update cart', 'woocommerce' ); ?></button>
+
+                <?php do_action( 'woocommerce_cart_actions' ); ?>
+
+                <?php wp_nonce_field( 'woocommerce-cart', 'woocommerce-cart-nonce' ); ?>
+            </td>
+        </tr>
+
+        <?php do_action( 'woocommerce_after_cart_contents' ); ?>
+        </tbody>
+    </table>
+    <?php do_action( 'woocommerce_after_cart_table' ); ?>
+</form>
+
+<?php do_action( 'woocommerce_before_cart_collaterals' ); ?>
+
+<div class="cart-collaterals">
+    <?php
+    /**
+     * Cart collaterals hook.
+     *
+     * @hooked woocommerce_cross_sell_display
+     * @hooked woocommerce_cart_totals - 10
+     */
+    do_action( 'woocommerce_cart_collaterals' );
+    ?>
+</div>
+
+<?php do_action( 'woocommerce_after_cart' ); ?>

--- a/wp-content/themes/twentytwenty-child/woocommerce/checkout/review-order.php
+++ b/wp-content/themes/twentytwenty-child/woocommerce/checkout/review-order.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Review order table
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/checkout/review-order.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates
+ * @version 3.8.0
+ *
+ * TEMPLATE OVERRIDE - Removed Footer Contents "Total" + "Subtotal" (lines 26, 44, 54)
+ */
+
+defined( 'ABSPATH' ) || exit;
+?>
+<table class="shop_table woocommerce-checkout-review-order-table">
+    <thead>
+    <tr>
+        <th class="product-name"><?php esc_html_e( 'Product', 'woocommerce' ); ?></th>
+        <!--Removed Subtotal Column-->
+    </tr>
+    </thead>
+    <tbody>
+    <?php
+    do_action( 'woocommerce_review_order_before_cart_contents' );
+
+    foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
+        $_product = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
+
+        if ( $_product && $_product->exists() && $cart_item['quantity'] > 0 && apply_filters( 'woocommerce_checkout_cart_item_visible', true, $cart_item, $cart_item_key ) ) {
+            ?>
+            <tr class="<?php echo esc_attr( apply_filters( 'woocommerce_cart_item_class', 'cart_item', $cart_item, $cart_item_key ) ); ?>">
+                <td class="product-name">
+                    <strong class="order-item-name">
+                        <?php echo apply_filters( 'woocommerce_cart_item_name', $_product->get_name(),
+                            $cart_item,
+                            $cart_item_key ) . '&nbsp;'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                    </strong>
+                    <?php echo apply_filters( 'woocommerce_checkout_cart_item_quantity', ' <strong class="product-quantity">' . sprintf( '&times;&nbsp;%s', $cart_item['quantity'] ) . '</strong>', $cart_item, $cart_item_key ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                    <?php echo wc_get_formatted_cart_item_data( $cart_item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                </td>
+                <!-- Removed Product Total -->
+            </tr>
+            <?php
+        }
+    }
+
+    do_action( 'woocommerce_review_order_after_cart_contents' );
+    ?>
+    </tbody>
+    <tfoot>
+
+    </tfoot>
+</table>

--- a/wp-content/themes/twentytwenty-child/woocommerce/checkout/thankyou.php
+++ b/wp-content/themes/twentytwenty-child/woocommerce/checkout/thankyou.php
@@ -17,6 +17,8 @@
  *
  * @edit - This page was edited at line 47 to add a 72 hour ETA when the order is placed. This page notifies
  * immediately after the order
+ *
+ * TEMPLATE OVERRIDE - removed total at line 75
  */
 
 if ( !defined( 'ABSPATH' ) ) {
@@ -70,10 +72,7 @@ if ( !defined( 'ABSPATH' ) ) {
               </li>
             <?php endif; ?>
 
-          <li class="woocommerce-order-overview__total total">
-              <?php _e( 'Total:', 'woocommerce' ); ?>
-            <strong><?php echo $order->get_formatted_order_total(); ?></strong>
-          </li>
+            <!-- Removed Order total -->
 
             <?php if ( $order->get_payment_method_title() ) : ?>
               <li class="woocommerce-order-overview__payment-method method">

--- a/wp-content/themes/twentytwenty-child/woocommerce/myaccount/dashboard.php
+++ b/wp-content/themes/twentytwenty-child/woocommerce/myaccount/dashboard.php
@@ -37,6 +37,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
     <p>
         <?php
+        /**
+         * REMOVED "shipping & billing" link here
+         */
         printf(
             __( 'From your account dashboard you can view your <a href="%1$s">recent orders</a> and <a href="%2$s">edit your password and account details</a>.', 'woocommerce' ),
             esc_url( wc_get_endpoint_url( 'orders' ) ),

--- a/wp-content/themes/twentytwenty-child/woocommerce/myaccount/dashboard.php
+++ b/wp-content/themes/twentytwenty-child/woocommerce/myaccount/dashboard.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * My Account Dashboard
+ *
+ * Shows the first intro screen on the account dashboard.
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/dashboard.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see         https://docs.woocommerce.com/document/template-structure/
+ * @package     WooCommerce/Templates
+ * @version     2.6.
+ *
+ * TEMPLATE OVERRIDE - remove any links to "address"
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+?>
+
+    <p>
+        <?php
+        printf(
+        /* translators: 1: user display name 2: logout url */
+            __( 'Hello %1$s (not %1$s? <a href="%2$s">Log out</a>)', 'woocommerce' ),
+            '<strong>' . esc_html( $current_user->display_name ) . '</strong>',
+            esc_url( wc_logout_url() )
+        );
+        ?>
+    </p>
+
+    <p>
+        <?php
+        printf(
+            __( 'From your account dashboard you can view your <a href="%1$s">recent orders</a> and <a href="%2$s">edit your password and account details</a>.', 'woocommerce' ),
+            esc_url( wc_get_endpoint_url( 'orders' ) ),
+            esc_url( wc_get_endpoint_url( 'edit-account' ) )
+        );
+        ?>
+    </p>
+
+<?php
+/**
+ * My Account dashboard.
+ *
+ * @since 2.6.0
+ */
+do_action( 'woocommerce_account_dashboard' );
+
+/**
+ * Deprecated woocommerce_before_my_account action.
+ *
+ * @deprecated 2.6.0
+ */
+do_action( 'woocommerce_before_my_account' );
+
+/**
+ * Deprecated woocommerce_after_my_account action.
+ *
+ * @deprecated 2.6.0
+ */
+do_action( 'woocommerce_after_my_account' );
+
+/* Omit closing PHP tag at the end of PHP files to avoid "headers already sent" issues. */

--- a/wp-content/themes/twentytwenty-child/woocommerce/myaccount/dashboard.php
+++ b/wp-content/themes/twentytwenty-child/woocommerce/myaccount/dashboard.php
@@ -16,7 +16,7 @@
  * @package     WooCommerce/Templates
  * @version     2.6.
  *
- * TEMPLATE OVERRIDE - remove any links to "address"
+ * TEMPLATE OVERRIDE - remove any links to "address" (line 44-46)
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/wp-content/themes/twentytwenty-child/woocommerce/myaccount/orders.php
+++ b/wp-content/themes/twentytwenty-child/woocommerce/myaccount/orders.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Orders
+ *
+ * Shows orders on the account page.
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/orders.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates
+ * @version 3.7.0
+ *
+ * TEMPLATE OVERRIDE - Removed $0.00 from "Total" column. Only including (line 63)
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+do_action( 'woocommerce_before_account_orders', $has_orders ); ?>
+
+<?php if ( $has_orders ) : ?>
+
+    <table class="woocommerce-orders-table woocommerce-MyAccount-orders shop_table shop_table_responsive my_account_orders account-orders-table">
+        <thead>
+        <tr>
+            <?php foreach ( wc_get_account_orders_columns() as $column_id => $column_name ) : ?>
+                <th class="woocommerce-orders-table__header woocommerce-orders-table__header-<?php echo esc_attr( $column_id ); ?>"><span class="nobr"><?php echo esc_html( $column_name ); ?></span></th>
+            <?php endforeach; ?>
+        </tr>
+        </thead>
+
+        <tbody>
+        <?php
+        foreach ( $customer_orders->orders as $customer_order ) {
+            $order      = wc_get_order( $customer_order ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
+            $item_count = $order->get_item_count() - $order->get_item_count_refunded();
+            ?>
+            <tr class="woocommerce-orders-table__row woocommerce-orders-table__row--status-<?php echo esc_attr( $order->get_status() ); ?> order">
+                <?php foreach ( wc_get_account_orders_columns() as $column_id => $column_name ) : ?>
+                    <td class="woocommerce-orders-table__cell woocommerce-orders-table__cell-<?php echo esc_attr( $column_id ); ?>" data-title="<?php echo esc_attr( $column_name ); ?>">
+                        <?php if ( has_action( 'woocommerce_my_account_my_orders_column_' . $column_id ) ) : ?>
+                            <?php do_action( 'woocommerce_my_account_my_orders_column_' . $column_id, $order ); ?>
+
+                        <?php elseif ( 'order-number' === $column_id ) : ?>
+                            <a href="<?php echo esc_url( $order->get_view_order_url() ); ?>">
+                                <?php echo esc_html( _x( '#', 'hash before order number', 'woocommerce' ) . $order->get_order_number() ); ?>
+                            </a>
+
+                        <?php elseif ( 'order-date' === $column_id ) : ?>
+                            <time datetime="<?php echo esc_attr( $order->get_date_created()->date( 'c' ) ); ?>"><?php echo esc_html( wc_format_datetime( $order->get_date_created() ) ); ?></time>
+
+                        <?php elseif ( 'order-status' === $column_id ) : ?>
+                            <?php echo esc_html( wc_get_order_status_name( $order->get_status() ) ); ?>
+
+                        <?php elseif ( 'order-total' === $column_id ) : ?>
+                            <?php
+                            /* translators: 1: formatted order total 2: total order items */
+                            echo wp_kses_post( sprintf( _n( '%1$s item', '%1$s items', $item_count, 'woocommerce' ), $item_count ) );
+                            ?>
+
+                        <?php elseif ( 'order-actions' === $column_id ) : ?>
+                            <?php
+                            $actions = wc_get_account_orders_actions( $order );
+
+                            if ( ! empty( $actions ) ) {
+                                foreach ( $actions as $key => $action ) { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
+                                    echo '<a href="' . esc_url( $action['url'] ) . '" class="woocommerce-button button ' . sanitize_html_class( $key ) . '">' . esc_html( $action['name'] ) . '</a>';
+                                }
+                            }
+                            ?>
+                        <?php endif; ?>
+                    </td>
+                <?php endforeach; ?>
+            </tr>
+            <?php
+        }
+        ?>
+        </tbody>
+    </table>
+
+    <?php do_action( 'woocommerce_before_account_orders_pagination' ); ?>
+
+    <?php if ( 1 < $customer_orders->max_num_pages ) : ?>
+        <div class="woocommerce-pagination woocommerce-pagination--without-numbers woocommerce-Pagination">
+            <?php if ( 1 !== $current_page ) : ?>
+                <a class="woocommerce-button woocommerce-button--previous woocommerce-Button woocommerce-Button--previous button" href="<?php echo esc_url( wc_get_endpoint_url( 'orders', $current_page - 1 ) ); ?>"><?php esc_html_e( 'Previous', 'woocommerce' ); ?></a>
+            <?php endif; ?>
+
+            <?php if ( intval( $customer_orders->max_num_pages ) !== $current_page ) : ?>
+                <a class="woocommerce-button woocommerce-button--next woocommerce-Button woocommerce-Button--next button" href="<?php echo esc_url( wc_get_endpoint_url( 'orders', $current_page + 1 ) ); ?>"><?php esc_html_e( 'Next', 'woocommerce' ); ?></a>
+            <?php endif; ?>
+        </div>
+    <?php endif; ?>
+
+<?php else : ?>
+    <div class="woocommerce-message woocommerce-message--info woocommerce-Message woocommerce-Message--info woocommerce-info">
+        <a class="woocommerce-Button button" href="<?php echo esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ); ?>">
+            <?php esc_html_e( 'Browse products', 'woocommerce' ); ?>
+        </a>
+        <?php esc_html_e( 'No order has been made yet.', 'woocommerce' ); ?>
+    </div>
+<?php endif; ?>
+
+<?php do_action( 'woocommerce_after_account_orders', $has_orders ); ?>

--- a/wp-content/themes/twentytwenty-child/woocommerce/order/order-details-customer.php
+++ b/wp-content/themes/twentytwenty-child/woocommerce/order/order-details-customer.php
@@ -14,7 +14,7 @@
  * @package WooCommerce/Templates
  * @version 3.4.4
  *
- * TEMPLATE OVERRIDE - remove shipping information
+ * TEMPLATE OVERRIDE - remove shipping information (line 33)
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/wp-content/themes/twentytwenty-child/woocommerce/order/order-details-customer.php
+++ b/wp-content/themes/twentytwenty-child/woocommerce/order/order-details-customer.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Order Customer Details
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/order/order-details-customer.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see     https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates
+ * @version 3.4.4
+ *
+ * TEMPLATE OVERRIDE - remove shipping information
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$show_shipping = ! wc_ship_to_billing_address_only() && $order->needs_shipping_address();
+?>
+<section class="woocommerce-customer-details">
+
+    <?php if ( $show_shipping ) : ?>
+
+    <section class="woocommerce-columns woocommerce-columns--2 woocommerce-columns--addresses col2-set addresses">
+        <div class="woocommerce-column woocommerce-column--1 woocommerce-column--billing-address col-1">
+
+            <?php endif; ?>
+
+            <!--Removed "Billing address here"-->
+
+            <address>
+                <!--Removed "N/A" here-->
+
+                <?php if ( $order->get_billing_phone() ) : ?>
+                    <p class="woocommerce-customer-details--phone"><?php echo esc_html( $order->get_billing_phone() ); ?></p>
+                <?php endif; ?>
+
+                <?php if ( $order->get_billing_email() ) : ?>
+                    <p class="woocommerce-customer-details--email"><?php echo esc_html( $order->get_billing_email() ); ?></p>
+                <?php endif; ?>
+            </address>
+
+            <?php if ( $show_shipping ) : ?>
+
+        </div><!-- /.col-1 -->
+
+        <div class="woocommerce-column woocommerce-column--2 woocommerce-column--shipping-address col-2">
+            <h2 class="woocommerce-column__title"><?php esc_html_e( 'Shipping address', 'woocommerce' ); ?></h2>
+            <address>
+                <?php echo wp_kses_post( $order->get_formatted_shipping_address( esc_html__( 'N/A', 'woocommerce' ) ) ); ?>
+            </address>
+        </div><!-- /.col-2 -->
+
+    </section><!-- /.col2-set -->
+
+<?php endif; ?>
+
+    <?php do_action( 'woocommerce_order_details_after_customer_details', $order ); ?>
+
+</section>

--- a/wp-content/themes/twentytwenty-child/woocommerce/order/order-details-item.php
+++ b/wp-content/themes/twentytwenty-child/woocommerce/order/order-details-item.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Order Item Details
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/order/order-details-item.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates
+ * @version 3.7.0
+ *
+ * TEMPLATE OVERRIDE - remove item price (line 56)
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! apply_filters( 'woocommerce_order_item_visible', true, $item ) ) {
+    return;
+}
+?>
+    <tr class="<?php echo esc_attr( apply_filters( 'woocommerce_order_item_class', 'woocommerce-table__line-item order_item', $item, $order ) ); ?>">
+
+        <td class="woocommerce-table__product-name product-name">
+            <?php
+            $is_visible        = $product && $product->is_visible();
+            $product_permalink = apply_filters( 'woocommerce_order_item_permalink', $is_visible ? $product->get_permalink( $item ) : '', $item, $order );
+
+            echo apply_filters( 'woocommerce_order_item_name', $product_permalink ? sprintf( '<a href="%s">%s</a>', $product_permalink, $item->get_name() ) : $item->get_name(), $item, $is_visible ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+            $qty          = $item->get_quantity();
+            $refunded_qty = $order->get_qty_refunded_for_item( $item_id );
+
+            if ( $refunded_qty ) {
+                $qty_display = '<del>' . esc_html( $qty ) . '</del> <ins>' . esc_html( $qty - ( $refunded_qty * -1 ) ) . '</ins>';
+            } else {
+                $qty_display = esc_html( $qty );
+            }
+
+            echo apply_filters( 'woocommerce_order_item_quantity_html', ' <strong class="product-quantity">' . sprintf( '&times;&nbsp;%s', $qty_display ) . '</strong>', $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+            do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order, false );
+
+            wc_display_item_meta( $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+            do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order, false );
+            ?>
+        </td>
+
+        <!--Removed Item total-->
+
+    </tr>
+
+<?php if ( $show_purchase_note && $purchase_note ) : ?>
+
+    <tr class="woocommerce-table__product-purchase-note product-purchase-note">
+
+        <td colspan="2"><?php echo wpautop( do_shortcode( wp_kses_post( $purchase_note ) ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
+
+    </tr>
+
+<?php endif; ?>

--- a/wp-content/themes/twentytwenty-child/woocommerce/order/order-details.php
+++ b/wp-content/themes/twentytwenty-child/woocommerce/order/order-details.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Order details
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/order/order-details.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see     https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates
+ * @version 3.7.0
+ *
+ * TEMPLATE OVERRIDE - remove "Total" (Line 54) column & "Subtotal", "Total" (Line 82)
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$order = wc_get_order( $order_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
+
+if ( ! $order ) {
+    return;
+}
+
+$order_items           = $order->get_items( apply_filters( 'woocommerce_purchase_order_item_types', 'line_item' ) );
+$show_purchase_note    = $order->has_status( apply_filters( 'woocommerce_purchase_note_order_statuses', array( 'completed', 'processing' ) ) );
+$show_customer_details = is_user_logged_in() && $order->get_user_id() === get_current_user_id();
+$downloads             = $order->get_downloadable_items();
+$show_downloads        = $order->has_downloadable_item() && $order->is_download_permitted();
+
+if ( $show_downloads ) {
+    wc_get_template(
+        'order/order-downloads.php',
+        array(
+            'downloads'  => $downloads,
+            'show_title' => true,
+        )
+    );
+}
+?>
+    <section class="woocommerce-order-details">
+        <?php do_action( 'woocommerce_order_details_before_order_table', $order ); ?>
+
+        <h2 class="woocommerce-order-details__title"><?php esc_html_e( 'Order details', 'woocommerce' ); ?></h2>
+
+        <table class="woocommerce-table woocommerce-table--order-details shop_table order_details">
+
+            <thead>
+            <tr>
+                <th class="woocommerce-table__product-name product-name"><?php esc_html_e( 'Product', 'woocommerce' ); ?></th>
+                <!--Removed Total Column-->
+            </tr>
+            </thead>
+
+            <tbody>
+            <?php
+            do_action( 'woocommerce_order_details_before_order_table_items', $order );
+
+            foreach ( $order_items as $item_id => $item ) {
+                $product = $item->get_product();
+
+                wc_get_template(
+                    'order/order-details-item.php',
+                    array(
+                        'order'              => $order,
+                        'item_id'            => $item_id,
+                        'item'               => $item,
+                        'show_purchase_note' => $show_purchase_note,
+                        'purchase_note'      => $product ? $product->get_purchase_note() : '',
+                        'product'            => $product,
+                    )
+                );
+            }
+
+            do_action( 'woocommerce_order_details_after_order_table_items', $order );
+            ?>
+            </tbody>
+
+            <!--Removed table footer (Subtotal & total)-->
+        </table>
+
+        <?php do_action( 'woocommerce_order_details_after_order_table', $order ); ?>
+    </section>
+
+<?php
+if ( $show_customer_details ) {
+    wc_get_template( 'order/order-details-customer.php', array( 'order' => $order ) );
+}


### PR DESCRIPTION
**Customer**
|#426 - https://projects.vta.org/projects/copy-center/work_packages/426 
|#427 - https://projects.vta.org/projects/copy-center/work_packages/427
|#428 - https://projects.vta.org/projects/copy-center/work_packages/428
|#432 - https://projects.vta.org/projects/copy-center/work_packages/432

**Admin** 
|#429 - https://projects.vta.org/projects/copy-center/work_packages/429
|#430 - https://projects.vta.org/projects/copy-center/work_packages/430
|#431 - https://projects.vta.org/projects/copy-center/work_packages/431

**Bugs**
|#434 - https://projects.vta.org/projects/copy-center/work_packages/434

This PR removes unused customer-facing fields. In the **My Account** page, we remove anything related to billing and shipping fields. All order items also remove **Totals and Subtotals**.

**Testing:**
- Go the **My Account** page and see if there are any links/tabs that refer to Shipping and Billing address.
- Make a test order and check if **Total** and **Subtotal** appear in the **Cart** page, **Checkout** page,  and **Order Confirmation** page.
- In the WooCommerce admin panel, change the Test Order's order status to **Proof Ready** and see if it triggers an email notification.
- On the home page while logged into your WordPress admin account, click Customize in the black admin menu to see if the Customizer loads.

**Requirements:**

### Customer Dashboards
- [x] Hide the **Downloads** tab from the **My Account** page.
- [x] Hide the **Address** tab from the **My Account** page.
- [x] Remove the **shipping & address** link in the **Dashboard** sub-page of the **My Account** page.
- [x] Remove **Billing Address** from the customers **Order Detail** page inside **My Account**.
- [x] Remove all unneeded pricing details from **Dashboard**

### Admin Dashboards
- [ ] ~Remove **Billing Address** & **Shipping Address** & **Downloads** from **Edit Order** page.~
- [ ] ~Remove User Billing & Address fields in the **Edit User** page.~ 
_Note: Copy Center Team is okay with these fields appearing. We may want to keep **Billing Address** since this is how WooCommerce saves customer phone number_

### Bugs & Other Requests (Meeting 5/4/2020)
- [x] ~Automatically render fields associated with Levels 1 & Levels 2~ Resolved via GF interface. Conditional Fields must be sequential...
- [x] ~Email on password reset.~ _Inactive Post SMTP plugin_
- [x] New Order Status "Proof Ready" (including email templates)
- [x] New User confirmation page.
- [x] Business Card Page buttons should be roughly the same size. Cancel should be on the left hand-size and continue on the right.
- [x] Customizer Page is currently broken (Top admin bar, click **Customize**)

_**Dashboard Styling:**_
- There may Be additional CSS styling to format WooCommerce sub-pages inside **My Account**.

**Considerations:**
We may want to re-implement some of these fields in the future. Pricing fields (total & subtotal) may be used in cost tracking, so we would have to revert some of these templates overrides.